### PR TITLE
Fixes padding and behavior of hash links

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import { ChakraProvider } from "@chakra-ui/react";
 import SiteLayout from "../components/SiteLayout";
 import theme from "../theme";
 import Fonts from "../components/Fonts";
+import "../styles/globals.css";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,20 +1,4 @@
-html,
-body {
-  padding: 0;
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
 * {
-  box-sizing: border-box;
-}
-
-.img__border-rounded {
-  border-radius: "32px";
+  scroll-padding-top: 6rem;
+  scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Issue
The nav bar has hash links to sections of the page, but needed a little padding for it to go to the correct place.

## Fix
- Added a simple global css `scroll-padding-top: 6rem; scroll-behavior: smooth;` to `globals.css`
- The `globals.css` file that was there was not being used, so cleared out everything else, replacing with just this one adjustment, then imported into `_app.tsx`

@jonathanprozzi Didn't see an easy fix for this using Chakra but I'm still new to it, let me know if there is another way to do this. 
